### PR TITLE
Make ci works on develop branch

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-pebble-0b58b0803.yml
+++ b/.github/workflows/azure-static-web-apps-witty-pebble-0b58b0803.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
+      - develop
       - master
 
 jobs:


### PR DESCRIPTION
Ci was not started in #14 because `develop` was selected as base